### PR TITLE
FS-14: Image snapshot capturing placeholder image instead of actual image during transition

### DIFF
--- a/FlowStackExample/FlowStackExample.xcodeproj/project.pbxproj
+++ b/FlowStackExample/FlowStackExample.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		EDC874752A4B8FDC0061C327 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDC874742A4B8FDC0061C327 /* ContentView.swift */; };
 		EDC874792A4B93CE0061C327 /* Product.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDC874782A4B93CE0061C327 /* Product.swift */; };
 		EDC8747B2A4CB99D0061C327 /* ProductDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDC8747A2A4CB99D0061C327 /* ProductDetailView.swift */; };
+		EDF7EEC02A5CCB62007ABF7C /* URLCache+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDF7EEBF2A5CCB62007ABF7C /* URLCache+Extensions.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -32,6 +33,7 @@
 		EDC874742A4B8FDC0061C327 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		EDC874782A4B93CE0061C327 /* Product.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Product.swift; sourceTree = "<group>"; };
 		EDC8747A2A4CB99D0061C327 /* ProductDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductDetailView.swift; sourceTree = "<group>"; };
+		EDF7EEBF2A5CCB62007ABF7C /* URLCache+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLCache+Extensions.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -69,6 +71,7 @@
 				EDC874742A4B8FDC0061C327 /* ContentView.swift */,
 				EDC8747A2A4CB99D0061C327 /* ProductDetailView.swift */,
 				EDC874782A4B93CE0061C327 /* Product.swift */,
+				EDF7EEBF2A5CCB62007ABF7C /* URLCache+Extensions.swift */,
 				EDC874732A4B8FB90061C327 /* Legacy Demo */,
 				ED07BFFA2A314DFE00C5DA72 /* Assets.xcassets */,
 				ED07BFFC2A314DFE00C5DA72 /* Preview Content */,
@@ -175,6 +178,7 @@
 				EDC874792A4B93CE0061C327 /* Product.swift in Sources */,
 				ED07C00A2A314E6200C5DA72 /* DisableInteractiveDismissTest.swift in Sources */,
 				EDC874752A4B8FDC0061C327 /* ContentView.swift in Sources */,
+				EDF7EEC02A5CCB62007ABF7C /* URLCache+Extensions.swift in Sources */,
 				ED07BFF72A314DFE00C5DA72 /* FlowStackExampleApp.swift in Sources */,
 				ED07C0082A314E6200C5DA72 /* InteractiveScrollViewDismissTest.swift in Sources */,
 				ED07C0092A314E6200C5DA72 /* ContentViewLegacy.swift in Sources */,

--- a/FlowStackExample/FlowStackExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/FlowStackExample/FlowStackExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,14 @@
+{
+  "pins" : [
+    {
+      "identity" : "swiftui-cached-async-image",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/lorenzofiamingo/swiftui-cached-async-image",
+      "state" : {
+        "revision" : "467a3d17479887943ab917a379e62bbaff60ac8a",
+        "version" : "2.1.1"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/FlowStackExample/FlowStackExample/ContentView.swift
+++ b/FlowStackExample/FlowStackExample/ContentView.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 import FlowStack
+import CachedAsyncImage
 
 struct ContentView: View {
     var body: some View {
@@ -62,9 +63,7 @@ struct ProductView: View {
     }
 
     private func image(url: URL) -> some View {
-        // TODO: Maybe replace with caching async image to ensure snapshot captures image and not placeholder
-        // https://github.com/lorenzofiamingo/swiftui-cached-async-image
-        AsyncImage(url: url, scale: 1) { image in
+        CachedAsyncImage(url: url, urlCache: .imageCache) { image in
             image
                 .resizable()
                 .scaledToFill()

--- a/FlowStackExample/FlowStackExample/ProductDetailView.swift
+++ b/FlowStackExample/FlowStackExample/ProductDetailView.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 import FlowStack
+import CachedAsyncImage
 
 struct ProductDetailView: View {
     @Environment(\.flowDismiss) var flowDismiss
@@ -71,10 +72,7 @@ struct ProductDetailView: View {
     }
 
     private func image(url: URL) -> some View {
-        // TODO: Maybe replace with caching async image to more quickly load image from cache when available.
-        // This could help transition be more "snappy" as far as image loading.
-        // https://github.com/lorenzofiamingo/swiftui-cached-async-image
-        AsyncImage(url: url, scale: 1) { image in
+        CachedAsyncImage(url: url, urlCache: .imageCache) { image in
             image
                 .resizable()
                 .scaledToFill()

--- a/FlowStackExample/FlowStackExample/URLCache+Extensions.swift
+++ b/FlowStackExample/FlowStackExample/URLCache+Extensions.swift
@@ -1,0 +1,12 @@
+//
+//  URLCache+Extensions.swift
+//  FlowStackExample
+//
+//  Created by Charles Hieger on 7/10/23.
+//
+
+import Foundation
+
+extension URLCache {
+    static let imageCache = URLCache(memoryCapacity: 512_000_000, diskCapacity: 10_000_000_000)
+}

--- a/Package.swift
+++ b/Package.swift
@@ -14,14 +14,14 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        // .package(url: /* package url */, from: "1.0.0"),
+        .package(name: "CachedAsyncImage", url: "https://github.com/lorenzofiamingo/swiftui-cached-async-image", from: "2.1.0"),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
         // Targets can depend on other targets in this package, and on products in packages this package depends on.
         .target(
             name: "FlowStack",
-            dependencies: []),
+            dependencies: ["CachedAsyncImage"]),
         .testTarget(
             name: "FlowStackTests",
             dependencies: ["FlowStack"]),


### PR DESCRIPTION
[FS-14: Image snapshot capturing placeholder image instead of actual image during transition](https://velosmobile.atlassian.net/browse/FS-14)

### Description

This PR addresses an issue where origin views used in a FlowLink with `transitionFromSnapshot: true` that incorporate SwiftUI's provided [AsyncImage](https://developer.apple.com/documentation/swiftui/asyncimage) resulted in the snapshot capturing the placeholder view instead of the fetched async image.

The reason being that FlowStack's snapshot mechanism triggers the origin view in a FlowLink to be reinitialized which in turn triggered another fetch of any remote images ( since `AsyncImage` does not cache fetched images) and thus a timing issue occurred where the snapshot was captured while the image was being fetched and the placeholder was currently in view.

The solution in this PR is to bring in the 3rd party library, [CachedAsyncImage](https://github.com/lorenzofiamingo/swiftui-cached-async-image) to facilitate image caching while maintaining a similar API to AsyncImage; similar enough that previous implementations using AsyncImage can pretty much just be updated to use `CachedAsycImage` with the addition of a larger cache to use for image caching. Setting up the specific cache will be the responsibility of the consumer since this will be specific to their particular use case.

### Images

#### Normal Speed

https://github.com/velos/FlowStack/assets/11927517/10c251f1-4c35-47f9-aa5c-2fe3682ba49f

#### Slow Animations

https://github.com/velos/FlowStack/assets/11927517/09d3b0e5-3081-45c8-aa36-19afa4cf6d7c

