### PR TITLE
FS-16: Add usage note to README for developers using images

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Below is a reference for all configuration values that a `FlowLink` view can tak
 
 ## Usage Notes
 
-⚠️ **You may see broken animation upon navigation, when displaying images from the Internet within your FlowLink views.** To fix this, you will need to use CachedAsyncImage in order to display remote images, as well as add additional code to define a larger cache size, as shown below...
+⚠️ **When displaying images from the Internet within your FlowLink views, you may see animation distortion when navigating to new views.** To remedy this, you will need to use CachedAsyncImage in order to display any remote images in your FlowLink views, as well as add additional code to define a larger cache size, as shown below...
 
 ```
 extension URLCache {
@@ -102,7 +102,7 @@ CachedAsyncImage(url: url, urlCache: .imageCache) { image in ... }
 
 In addition, we recommend using the `transitionFromSnapshot` and `animateFromAnchor` parameters when displaying images in your FlowLink views. See [Configuration](https://github.com/velos/FlowStack/#configuration) above for details.
 
-A working example of `CachedAsyncImage` can be seen in [ContentView.swift](https://github.com/velos/FlowStack/blob/develop/FlowStackExample/FlowStackExample/ContentView.swift) on the official FlowStack example project.
+A working example of this approach can be seen in [ContentView.swift](https://github.com/velos/FlowStack/blob/develop/FlowStackExample/FlowStackExample/ContentView.swift) on the official FlowStack example project.
 
 ## Contribute
 


### PR DESCRIPTION
### Overview

**[FS-16: Add usage note to README for developers using images](https://velosmobile.atlassian.net/browse/FS-16)**

In order to maintain compatibility with CachedAyncImage, developers using images in their FlowStack will need to specify cache capacity explicitly, as shown below:

---

### AC

- [x] Establish a Usage Notes section in the README
- [x] Include background and snippet above, along with any other guidance that developers may find helpful.

---

### Preview

Click below to preview the latest README as contained in this PR:

https://github.com/velos/FlowStack/blob/feature/FS-16-usage-note-for-images/README.md