### PR TITLE
FS-33: Flowlink Content Hit Target Area

### DIFF
--- a/FlowStackExample/FlowStackExample/ProductRow.swift
+++ b/FlowStackExample/FlowStackExample/ProductRow.swift
@@ -14,7 +14,7 @@ struct ProductRow: View {
 
     var body: some View {
         image(url: product.imageUrl)
-            .allowsHitTesting(false)
+            .allowsHitTesting(false) // https://stackoverflow.com/a/74711565
             .aspectRatio(4 / 3, contentMode: .fill)
             .overlay(alignment: .topTrailing) {
                 Text(product.name)


### PR DESCRIPTION
### Discussion

In the Example project, the issue was that user taps to the the lower 1/3 region of a given FlowLink row were not being registered and thereby no navigation to the detail was being initiated.

In looking at the UI debugger, it seems that even though the content of the FlowLink was being clipped via clipShape modifier and visually appeared correct, the image was exceeding the bounds of it's row and blocking hits to the row above it.

<img width="387" alt="hittest_debug" src="https://github.com/velos/FlowStack/assets/11927517/6563d32a-3711-404c-9f3a-0e31023f8b69">

There are several solutions proposed in [This SO post](https://stackoverflow.com/questions/63300411/clipped-not-actually-clips-the-image-in-swiftui), most which involve setting a contentShape, however that didn't seem to work in this case (having tried many permutations of how that could be applied).

The [solution that did work](https://stackoverflow.com/a/74711565) just disables the hit testing for the offending overlapping view (in our case the image). This seems to remedy the issue, by removing the image from hit testing completely, however the overlap seen on the debugger still remains, though visually everything is rendered as expected. It would have been more satisfying to have been able to actually get that image to _really_ be clipped at the edges of the desired clipped bounds, but that just wasn't happening.

>[!Note]
> There are some special things going on with how the image is setup in our case (via SwiftUI modifiers) in order to allow for dynamic sizing based on aspect ratio and content mode fill, while maintaining a non-stretched/distorted state. There's a bit more too this then one might initially expect for such a seemingly common and essential use case of having an image that dynamically sizes to fill a frame of a specified aspect ratio without distortion. [More details on that here](https://alejandromp.com/blog/image-aspectratio-without-frames/)

### Images

#### Showing hits correctly registered at all points in Flow Link row area

https://github.com/velos/FlowStack/assets/11927517/fffe8f63-8d9a-4d1f-a30d-62f4e88d6e30

