### PR TITLE
FS-38: iOS 17 Tap Area Displacement in Some Cases

### DIFF
--- a/Sources/FlowStack/View+InteractiveDismiss.swift
+++ b/Sources/FlowStack/View+InteractiveDismiss.swift
@@ -161,8 +161,6 @@ class InteractiveDismissCoordinator: NSObject, ObservableObject, UIGestureRecogn
 
     fileprivate var scrollView: UIScrollView? {
         didSet {
-            scrollView?.contentInsetAdjustmentBehavior = .never
-
             if let recognizer = scrollView?.panGestureRecognizer {
                 panGestureRecognizer.shouldRequireFailure(of: recognizer)
                 edgeGestureRecognizer.shouldRequireFailure(of: recognizer)


### PR DESCRIPTION
### Discussion

In another project using FlowStack, it was observed that on iOS 17, buttons (or views with tap gestures) would have their tappable areas displaced below their associated rendered content, proportional to the content inset of the top safe area.

Removing `scrollView?.contentInsetAdjustmentBehavior = .never` fixed the issue on iOS 17 and did not have any observed adverse affect on iOS 15 and 16.

### Images

https://github.com/velos/FlowStack/assets/11927517/1a4aaa37-9f1d-40a0-b390-1327b72b44bd


