### PR TITLE
Flashing Content Fix

### DIFF
--- a/Sources/FlowStack/FlowLink.swift
+++ b/Sources/FlowStack/FlowLink.swift
@@ -364,7 +364,6 @@ public struct FlowLink<Label>: View where Label: View {
         label()
             .onButtonGesture {
                 buttonPressed = true
-                print("🦦 buttonPressed -> \(buttonPressed)")
                 // check for sibling elements and return early if we already have a presented element at this depth
                 guard !hasSiblingElement else {
                     return
@@ -391,7 +390,6 @@ public struct FlowLink<Label>: View where Label: View {
                 if configuration.animateFromAnchor && overrideAnchor == nil {
                     button
                         .opacity(isShowing ? 1.0 : 0.0)
-//                        .transition(.invisible)
                 } else if configuration.animateFromAnchor {
                     button
                         .transition(.opacityPercent)
@@ -445,7 +443,6 @@ public struct FlowLink<Label>: View where Label: View {
             buttonPressed = false
         } else if isShowing == false {
             DispatchQueue.main.asyncAfter(deadline: .now() + flowDuration) { withAnimation(nil) {
-                print("🦦 isShowing")
                 isShowing = true
             }}
         }

--- a/Sources/FlowStack/FlowLink.swift
+++ b/Sources/FlowStack/FlowLink.swift
@@ -390,8 +390,9 @@ public struct FlowLink<Label>: View where Label: View {
                 if configuration.animateFromAnchor && overrideAnchor == nil {
                     button
                         .opacity(isShowing ? 1.0 : 0.0)
-                        /// Diisable animations coming from adding to the flowstack before dismissing
-                        .overrideAnimation()
+                        /// Override an animation with an animation that does nothing
+                        /// Leaving a flowlayer too early can cause an un-wanted animation
+                        .ignoreAnimation()
                 } else if configuration.animateFromAnchor {
                     button
                         .transition(.opacityPercent)
@@ -451,23 +452,22 @@ public struct FlowLink<Label>: View where Label: View {
     }
 }
 
-
-private struct OverrideAnimationModifier: ViewModifier {
+private struct IgnoreAnimationModifier: ViewModifier {
     @State var shouldDisplay = true
     let transition: AnyTransition
     func body(content: Content) -> some View {
         render(content)
             .animation(nil, value: shouldDisplay)
             .transition(transition)
-
     }
     @ViewBuilder
     private func render(_ content: Content) -> some View {
         content
     }
 }
+
 private extension View {
-    func overrideAnimation(transition: AnyTransition = .identity) -> some View {
-        modifier(OverrideAnimationModifier(transition: transition))
+    func ignoreAnimation(transition: AnyTransition = .identity) -> some View {
+        modifier(IgnoreAnimationModifier(transition: transition))
     }
 }

--- a/Sources/FlowStack/FlowLink.swift
+++ b/Sources/FlowStack/FlowLink.swift
@@ -209,7 +209,7 @@ public struct FlowLink<Label>: View where Label: View {
         /// Creates a configuration with the specified parameters.
         /// - Parameters:
         ///   - animateFromAnchor: Whether the destination view should transition visually from the bounds of the associated flow link contents or flow link animation anchor.
-        ///   - transitionFromSnapshot: Whether a snapshot image of t🦦he flow link contents should be used during a transition.
+        ///   - transitionFromSnapshot: Whether a snapshot image of the flow link contents should be used during a transition.
         ///   - cornerRadius: The corner radius applied to the transitioning destination view. This value should typically match the corner radius of the flow link contents or flow link animation anchor for visual consistency.
         ///   - cornerStyle: The corner style applied to the transitioning destination view. This value should typically match the corner style of the flow link contents or flow link animation anchor for visual consistency.
         ///   - shadowRadius: The shadow radius applied to the transitioning destination view. This value should typically match the shadow radius of the flow link contents or flow link animation anchor for visual consistency.

--- a/Sources/FlowStack/FlowLink.swift
+++ b/Sources/FlowStack/FlowLink.swift
@@ -390,7 +390,7 @@ public struct FlowLink<Label>: View where Label: View {
                 if configuration.animateFromAnchor && overrideAnchor == nil {
                     button
                         .opacity(isShowing ? 1.0 : 0.0)
-                        /// Override an animation with an animation that does nothing
+                        /// (Workaround) Override an animation with an animation that does nothing
                         /// Leaving a flowlayer too early can cause an un-wanted animation
                         .ignoreAnimation()
                 } else if configuration.animateFromAnchor {

--- a/Sources/FlowStack/FlowLink.swift
+++ b/Sources/FlowStack/FlowLink.swift
@@ -390,6 +390,11 @@ public struct FlowLink<Label>: View where Label: View {
                 if configuration.animateFromAnchor && overrideAnchor == nil {
                     button
                         .opacity(isShowing ? 1.0 : 0.0)
+                        /// Have to disable animations coming from adding to the flowstack before dismissing
+                        .delayAppearance(bySeconds: 0)
+                            .transaction { transaction in
+                                transaction.disablesAnimations = true
+                            }
                 } else if configuration.animateFromAnchor {
                     button
                         .transition(.opacityPercent)
@@ -446,5 +451,46 @@ public struct FlowLink<Label>: View where Label: View {
                 isShowing = true
             }}
         }
+    }
+}
+
+
+struct DelayAppearanceModifier: ViewModifier {
+    @State var shouldDisplay = false
+
+    let delay: Double
+    let transition: AnyTransition
+
+    func body(content: Content) -> some View {
+        render(content)
+            // we want to allow transition, so we have to attach aninamtion and transition here
+            // To disable this, use .transaction modifier after this modifier to override this
+            .animation(nil, value: shouldDisplay)
+            .transition(transition)
+            .task {
+                try? await Task.sleep(nanoseconds: .init(delay * 1000_000_000))
+                shouldDisplay = true
+            }
+    }
+
+    @ViewBuilder
+    private func render(_ content: Content) -> some View {
+        if shouldDisplay {
+            content
+        } else {
+            content
+                .hidden()
+        }
+    }
+}
+
+extension View {
+    /// Delay the appearance of this view
+    /// - Parameters:
+    ///   - seconds: by how may seconds
+    ///   - transition: what transition effect to use on appearance
+    /// - Returns: the modifiere view
+    func delayAppearance(bySeconds seconds: Double, transition: AnyTransition = .slide) -> some View {
+        modifier(DelayAppearanceModifier(delay: seconds, transition: transition))
     }
 }

--- a/Sources/FlowStack/FlowLink.swift
+++ b/Sources/FlowStack/FlowLink.swift
@@ -370,7 +370,7 @@ public struct FlowLink<Label>: View where Label: View {
                 }
                 Task {
                     if configuration.transitionFromSnapshot {
-                        context?.snapshot = updateSnapshot()
+                        context?.snapshot = await updateSnapshot()
                     }
                     if let value = value {
                         withTransaction(transaction) {

--- a/Sources/FlowStack/FlowLink.swift
+++ b/Sources/FlowStack/FlowLink.swift
@@ -370,7 +370,7 @@ public struct FlowLink<Label>: View where Label: View {
                 }
                 Task {
                     if configuration.transitionFromSnapshot {
-                        context?.snapshot = await updateSnapshot()
+                        context?.snapshot = updateSnapshot()
                     }
                     if let value = value {
                         withTransaction(transaction) {

--- a/Sources/FlowStack/FlowStack.swift
+++ b/Sources/FlowStack/FlowStack.swift
@@ -406,7 +406,7 @@ public struct CustomSmoothAnimation {
     var duration: Double
     var bounce: Double
 
-    static let defaultAnimation = CustomSmoothAnimation(duration: 0.20, bounce: 0.2)
+    static let defaultAnimation = CustomSmoothAnimation(duration: 0.24, bounce: 0.2)
 }
 
 public extension Animation {

--- a/Sources/FlowStack/FlowStack.swift
+++ b/Sources/FlowStack/FlowStack.swift
@@ -400,7 +400,7 @@ struct FlowStack_Previews: PreviewProvider {
     }
 }
 
-/// Object for passable parameters for .smooth Animation
+/// Object for passable parameters for smooth Animation
 /// Had to be an animation type with a duration value so that it's trackable for flowStack
 public struct CustomSmoothAnimation {
     var duration: Double

--- a/Sources/FlowStack/FlowStack.swift
+++ b/Sources/FlowStack/FlowStack.swift
@@ -373,6 +373,17 @@ extension EnvironmentValues {
     }
 }
 
+struct FlowPathAnimationKey: EnvironmentKey {
+    static let defaultValue: Double = CustomSmoothAnimation.defaultAnimation.duration
+}
+
+public extension EnvironmentValues {
+    var flowAnimationDuration: Double {
+        get { self[FlowPathAnimationKey.self] }
+        set { self[FlowPathAnimationKey.self] = newValue }
+    }
+}
+
 @available(iOS 16.0, *)
 struct FlowStack_Previews: PreviewProvider {
     static var previews: some View {

--- a/Sources/FlowStack/FlowStack.swift
+++ b/Sources/FlowStack/FlowStack.swift
@@ -406,17 +406,21 @@ public struct CustomSmoothAnimation {
     var duration: Double
     var bounce: Double
 
-    static let defaultAnimation = CustomSmoothAnimation(duration: 0.24, bounce: 0.2)
+    static let `default` = CustomSmoothAnimation(duration: 0.24, bounce: 0.2)
+
+    var animation: Animation {
+        .smooth(
+            duration: duration,
+            extraBounce: bounce
+        )
+    }
 }
 
 public extension Animation {
 
     /// The default animation to use during flow transitions.
     static var defaultFlow: Animation {
-        .smooth(
-            duration: CustomSmoothAnimation.defaultAnimation.duration,
-            extraBounce: CustomSmoothAnimation.defaultAnimation.bounce
-        )
+        CustomSmoothAnimation.default.animation
     }
 }
 

--- a/Sources/FlowStack/FlowStack.swift
+++ b/Sources/FlowStack/FlowStack.swift
@@ -211,7 +211,7 @@ public struct FlowStack<Root: View, Overlay: View>: View {
 
     @Binding private var path: FlowPath
     @State private var internalPath: FlowPath = FlowPath()
-    private var animation: Animation
+    private var animation: CustomSmoothAnimation
 
     private var overlayAlignment: Alignment
     private var root: () -> Root
@@ -228,11 +228,11 @@ public struct FlowStack<Root: View, Overlay: View>: View {
     ///   - animation: The animation to use during flow transitions.
     ///   - root: The view to display when the stack is empty.
     ///   - overlay: The view to overlay on the FlowStack. This view is always visible in front of any view presented by the flow stack.
-    public init(overlayAlignment: Alignment = .center, animation: Animation = .defaultFlow, @ViewBuilder root: @escaping () -> Root, @ViewBuilder overlay: @escaping () -> Overlay) {
+    public init(overlayAlignment: Alignment = .center, animation: CustomSmoothAnimation?=nil, @ViewBuilder root: @escaping () -> Root, @ViewBuilder overlay: @escaping () -> Overlay) {
         self.root = root
         self.overlay = overlay
         self.overlayAlignment = overlayAlignment
-        self.animation = animation
+        self.animation = animation ?? .defaultAnimation
 
         self.usesInternalPath = true
         self._path = Binding(get: { FlowPath() }, set: { _ in })
@@ -245,12 +245,12 @@ public struct FlowStack<Root: View, Overlay: View>: View {
     ///   - animation: The animation to use during flow transitions.
     ///   - root: The view to display when the stack is empty.
     ///   - overlay: The view to overlay on the FlowStack. This view is always visible in front of any view presented by the flow stack.
-    public init(path: Binding<FlowPath>, overlayAlignment: Alignment = .center, animation: Animation = .defaultFlow, @ViewBuilder root: @escaping () -> Root, @ViewBuilder overlay: @escaping () -> Overlay) {
+    public init(path: Binding<FlowPath>, overlayAlignment: Alignment = .center, animation: CustomSmoothAnimation?=nil, @ViewBuilder root: @escaping () -> Root, @ViewBuilder overlay: @escaping () -> Overlay) {
         self.root = root
         self.overlay = overlay
         self.overlayAlignment = overlayAlignment
         self._path = path
-        self.animation = animation
+        self.animation = animation ?? .defaultAnimation
     }
 
     private func destination(for instance: any (Hashable & Equatable)) -> AnyDestination? {
@@ -291,7 +291,7 @@ public struct FlowStack<Root: View, Overlay: View>: View {
     }
 
     private var transaction: Transaction {
-        var transaction = Transaction(animation: animation)
+        var transaction = Transaction(animation: animation == nil ? .defaultFlow : .smooth(duration: animation.duration, extraBounce: animation.bounce))
         transaction.disablesAnimations = true
         return transaction
     }
@@ -324,6 +324,7 @@ public struct FlowStack<Root: View, Overlay: View>: View {
                 .environment(\.flowDepth, -1)
         }
         .environment(\.flowPath, pathToUse)
+        .environment(\.flowAnimationDuration, animation.duration)
         .environment(\.flowTransaction, transaction)
         .environmentObject(destinationLookup)
         .environmentObject(accessibilityManager)
@@ -337,14 +338,14 @@ public extension FlowStack where Overlay == EmptyView {
     /// - Parameters:
     ///   - animation: The animation to use during flow transitions.
     ///   - root: The view to display when the stack is empty.
-    init(animation: Animation = .defaultFlow, @ViewBuilder root: @escaping () -> Root) {
+    init(animation: CustomSmoothAnimation? = nil, @ViewBuilder root: @escaping () -> Root) {
         self.root = root
         self.overlay = { EmptyView() }
         self.overlayAlignment = .center
 
         self.usesInternalPath = true
         self._path = Binding(get: { FlowPath() }, set: { _ in })
-        self.animation = animation
+        self.animation = animation ?? .defaultAnimation
     }
 
     /// Creates a flow stack with heterogeneous navigation state that you can control.
@@ -352,12 +353,12 @@ public extension FlowStack where Overlay == EmptyView {
     ///   - path: A Binding to the flow path for this stack.
     ///   - animation: The animation to use during flow transitions.
     ///   - root: The view to display when the stack is empty.
-    init(path: Binding<FlowPath>, animation: Animation = .defaultFlow, @ViewBuilder root: @escaping () -> Root) {
+    init(path: Binding<FlowPath>, animation: CustomSmoothAnimation? = nil, @ViewBuilder root: @escaping () -> Root) {
         self.root = root
         self.overlay = { EmptyView() }
         self.overlayAlignment = .center
         self._path = path
-        self.animation = animation
+        self.animation = animation ?? .defaultAnimation
     }
 }
 
@@ -388,10 +389,24 @@ struct FlowStack_Previews: PreviewProvider {
     }
 }
 
+/// Object for passable parameters for smoothAnimation
+/// Had to be an animation type with a duration value so that it's trackable for flowStack
+public struct CustomSmoothAnimation {
+    var duration: Double
+    var bounce: Double
+
+    static let defaultAnimation = CustomSmoothAnimation(duration: 0.20, bounce: 0.2)
+}
+
 public extension Animation {
 
     /// The default animation to use during flow transitions.
-    static var defaultFlow: Animation { .interpolatingSpring(stiffness: 500, damping: 35) }
+    static var defaultFlow: Animation {
+        .smooth(
+            duration: CustomSmoothAnimation.defaultAnimation.duration,
+            extraBounce: CustomSmoothAnimation.defaultAnimation.bounce
+        )
+    }
 }
 
 struct FlowTransactionModifier: ViewModifier {

--- a/Sources/FlowStack/FlowStack.swift
+++ b/Sources/FlowStack/FlowStack.swift
@@ -211,7 +211,7 @@ public struct FlowStack<Root: View, Overlay: View>: View {
 
     @Binding private var path: FlowPath
     @State private var internalPath: FlowPath = FlowPath()
-    private var animation: CustomSmoothAnimation
+    private var customSmoothAnimation: CustomSmoothAnimation
 
     private var overlayAlignment: Alignment
     private var root: () -> Root
@@ -228,11 +228,11 @@ public struct FlowStack<Root: View, Overlay: View>: View {
     ///   - animation: The animation to use during flow transitions.
     ///   - root: The view to display when the stack is empty.
     ///   - overlay: The view to overlay on the FlowStack. This view is always visible in front of any view presented by the flow stack.
-    public init(overlayAlignment: Alignment = .center, animation: CustomSmoothAnimation?=nil, @ViewBuilder root: @escaping () -> Root, @ViewBuilder overlay: @escaping () -> Overlay) {
+    public init(overlayAlignment: Alignment = .center, customSmoothAnimation: CustomSmoothAnimation?=nil, @ViewBuilder root: @escaping () -> Root, @ViewBuilder overlay: @escaping () -> Overlay) {
         self.root = root
         self.overlay = overlay
         self.overlayAlignment = overlayAlignment
-        self.animation = animation ?? .defaultAnimation
+        self.customSmoothAnimation = customSmoothAnimation ?? CustomSmoothAnimation.default
 
         self.usesInternalPath = true
         self._path = Binding(get: { FlowPath() }, set: { _ in })
@@ -245,12 +245,12 @@ public struct FlowStack<Root: View, Overlay: View>: View {
     ///   - animation: The animation to use during flow transitions.
     ///   - root: The view to display when the stack is empty.
     ///   - overlay: The view to overlay on the FlowStack. This view is always visible in front of any view presented by the flow stack.
-    public init(path: Binding<FlowPath>, overlayAlignment: Alignment = .center, animation: CustomSmoothAnimation?=nil, @ViewBuilder root: @escaping () -> Root, @ViewBuilder overlay: @escaping () -> Overlay) {
+    public init(path: Binding<FlowPath>, overlayAlignment: Alignment = .center, customSmoothAnimation: CustomSmoothAnimation?=nil, @ViewBuilder root: @escaping () -> Root, @ViewBuilder overlay: @escaping () -> Overlay) {
         self.root = root
         self.overlay = overlay
         self.overlayAlignment = overlayAlignment
         self._path = path
-        self.animation = animation ?? .defaultAnimation
+        self.customSmoothAnimation = customSmoothAnimation ?? CustomSmoothAnimation.default
     }
 
     private func destination(for instance: any (Hashable & Equatable)) -> AnyDestination? {
@@ -291,7 +291,7 @@ public struct FlowStack<Root: View, Overlay: View>: View {
     }
 
     private var transaction: Transaction {
-        var transaction = Transaction(animation: animation == nil ? .defaultFlow : .smooth(duration: animation.duration, extraBounce: animation.bounce))
+        var transaction = Transaction(animation: customSmoothAnimation.animation)
         transaction.disablesAnimations = true
         return transaction
     }
@@ -324,7 +324,7 @@ public struct FlowStack<Root: View, Overlay: View>: View {
                 .environment(\.flowDepth, -1)
         }
         .environment(\.flowPath, pathToUse)
-        .environment(\.flowAnimationDuration, animation.duration)
+        .environment(\.flowAnimationDuration, customSmoothAnimation.duration)
         .environment(\.flowTransaction, transaction)
         .environmentObject(destinationLookup)
         .environmentObject(accessibilityManager)
@@ -338,14 +338,14 @@ public extension FlowStack where Overlay == EmptyView {
     /// - Parameters:
     ///   - animation: The animation to use during flow transitions.
     ///   - root: The view to display when the stack is empty.
-    init(animation: CustomSmoothAnimation? = nil, @ViewBuilder root: @escaping () -> Root) {
+    init(customSmoothAnimation: CustomSmoothAnimation? = nil, @ViewBuilder root: @escaping () -> Root) {
         self.root = root
         self.overlay = { EmptyView() }
         self.overlayAlignment = .center
 
         self.usesInternalPath = true
         self._path = Binding(get: { FlowPath() }, set: { _ in })
-        self.animation = animation ?? .defaultAnimation
+        self.customSmoothAnimation = customSmoothAnimation ?? CustomSmoothAnimation.default
     }
 
     /// Creates a flow stack with heterogeneous navigation state that you can control.
@@ -353,12 +353,12 @@ public extension FlowStack where Overlay == EmptyView {
     ///   - path: A Binding to the flow path for this stack.
     ///   - animation: The animation to use during flow transitions.
     ///   - root: The view to display when the stack is empty.
-    init(path: Binding<FlowPath>, animation: CustomSmoothAnimation? = nil, @ViewBuilder root: @escaping () -> Root) {
+    init(path: Binding<FlowPath>, customSmoothAnimation: CustomSmoothAnimation? = nil, @ViewBuilder root: @escaping () -> Root) {
         self.root = root
         self.overlay = { EmptyView() }
         self.overlayAlignment = .center
         self._path = path
-        self.animation = animation ?? .defaultAnimation
+        self.customSmoothAnimation = customSmoothAnimation ??  CustomSmoothAnimation.default
     }
 }
 
@@ -374,7 +374,7 @@ extension EnvironmentValues {
 }
 
 struct FlowPathAnimationKey: EnvironmentKey {
-    static let defaultValue: Double = CustomSmoothAnimation.defaultAnimation.duration
+    static let defaultValue: Double = CustomSmoothAnimation.default.duration
 }
 
 public extension EnvironmentValues {

--- a/Sources/FlowStack/FlowStack.swift
+++ b/Sources/FlowStack/FlowStack.swift
@@ -400,7 +400,7 @@ struct FlowStack_Previews: PreviewProvider {
     }
 }
 
-/// Object for passable parameters for smoothAnimation
+/// Object for passable parameters for .smooth Animation
 /// Had to be an animation type with a duration value so that it's trackable for flowStack
 public struct CustomSmoothAnimation {
     var duration: Double

--- a/Sources/FlowStack/FlowTransition.swift
+++ b/Sources/FlowStack/FlowTransition.swift
@@ -71,8 +71,8 @@ extension AnyTransition {
 
     static var invisible: AnyTransition {
         AnyTransition.modifier(
-            active: InvisibleModifier(percent: 0),
-            identity: InvisibleModifier(percent: 1)
+            active: InvisibleModifier(percent: 1),
+            identity: InvisibleModifier(percent: 0)
         )
     }
 
@@ -86,7 +86,7 @@ extension AnyTransition {
 
         func body(content: Content) -> some View {
             content
-                .opacity(percent == 1.0 ? 1 : 0)
+                .opacity(percent == 1.0 ? 0 : 1)
         }
     }
 
@@ -110,7 +110,7 @@ extension AnyTransition {
         @Environment(\.horizontalSizeClass) var horizontalSizeClass
 
         var cornerRadius: CGFloat { context.cornerRadius + ((UIScreen.displayCornerRadius ?? 20) - context.cornerRadius) * percent }
-        
+
         var isPresentedFullscreen: Bool {
             horizontalSizeClass == .compact || availableSize.width - 2 * Constants.minVerticalPadding < Constants.maxWidth
         }

--- a/Sources/FlowStack/FlowTransition.swift
+++ b/Sources/FlowStack/FlowTransition.swift
@@ -69,27 +69,6 @@ extension AnyTransition {
         )
     }
 
-    static var invisible: AnyTransition {
-        AnyTransition.modifier(
-            active: InvisibleModifier(percent: 1),
-            identity: InvisibleModifier(percent: 0)
-        )
-    }
-
-    struct InvisibleModifier: AnimatableModifier {
-        var percent: Double
-
-        var animatableData: Double {
-            get { percent }
-            set { percent = newValue }
-        }
-
-        func body(content: Content) -> some View {
-            content
-                .opacity(percent == 1.0 ? 0 : 1)
-        }
-    }
-
     struct FlowPresentModifier: Animatable, ViewModifier {
         var percent: CGFloat
         var context: PathContext


### PR DESCRIPTION
Changes: 
- Flashing Content No longer happens from dismissal of FlowStack Views
- Animations as a consequence aren't nearly as customizable as this fix required knowing the duration of an animation. FlowStack as of now will only use the .smooth Animation. The parameter ```animation``` now asks for an optional ```CustomSmoothAnimation(duration: Double, bounce: Double)``` rather than an ```Animation``` if the a user chooses not to use the default values