### PR TITLE
Snapshot Theme Toggling

### DIFF
--- a/Sources/FlowStack/FlowLink.swift
+++ b/Sources/FlowStack/FlowLink.swift
@@ -371,7 +371,6 @@ public struct FlowLink<Label>: View where Label: View {
                 }
                 Task {
                     if configuration.transitionFromSnapshot {
-                        print("🦦 current colorScheme: -> \(colorScheme)")
                         context?.snapshot = snapshots[colorScheme]
                     }
                     if let value = value {

--- a/Sources/FlowStack/FlowLink.swift
+++ b/Sources/FlowStack/FlowLink.swift
@@ -303,7 +303,7 @@ public struct FlowLink<Label>: View where Label: View {
         return path?.wrappedValue.elements.map(\.context?.linkDepth).contains(flowDepth) ?? false
     }
 
-    private func updateSnapshot(colorScheme: ColorScheme) -> UIImage? {
+    private func createSnapshot(colorScheme: ColorScheme) -> UIImage? {
         guard let size = size else { return nil }
 
         let frame = CGRect(origin: .zero, size: size)
@@ -407,12 +407,7 @@ public struct FlowLink<Label>: View where Label: View {
             snapshots[newScheme]
             path?.wrappedValue.updateSnapshots(from: newScheme)
         }
-        .onAppear {
-            let lightImage = updateSnapshot(colorScheme: .light)
-            let darkImage = updateSnapshot(colorScheme: .dark)
-            snapshots[.light] = lightImage
-            snapshots[.dark] = darkImage
-        }
+        .onAppear { initSnapshots() }
         .background(
             GeometryReader { proxy in
                 Color.clear
@@ -446,6 +441,8 @@ public struct FlowLink<Label>: View where Label: View {
             )
         })
         .onPreferenceChange(PathContextKey.self) { value in
+//            print("🦦 value hash id? \(value?.hashValue)")
+//            print("🦦 \(value?.linkDepth ?? 0)")
             context = value
         }
         .onPreferenceChange(AnimationAnchorKey.self) { anchor in
@@ -462,6 +459,17 @@ public struct FlowLink<Label>: View where Label: View {
             DispatchQueue.main.asyncAfter(deadline: .now() + flowDuration) { withAnimation(nil) {
                 isShowing = true
             }}
+        }
+    }
+
+    private func initSnapshots() {
+        Task {
+            // Prevent Snapshot from being taken too early
+            try? await Task.sleep(10000)
+                let lightImage = createSnapshot(colorScheme: .light)
+                let darkImage = createSnapshot(colorScheme: .dark)
+                snapshots[.light] = lightImage
+                snapshots[.dark] = darkImage
         }
     }
 }

--- a/Sources/FlowStack/FlowLink.swift
+++ b/Sources/FlowStack/FlowLink.swift
@@ -267,7 +267,6 @@ public struct FlowLink<Label>: View where Label: View {
     @State private var environment = EnvironmentValues()
     @State private var refreshButton = UUID()
 
-
     /// Creates a flow link that presents the view corresponding to a value.
     ///
     /// When someone activates the flow link that this initializer
@@ -441,8 +440,6 @@ public struct FlowLink<Label>: View where Label: View {
             )
         })
         .onPreferenceChange(PathContextKey.self) { value in
-//            print("🦦 value hash id? \(value?.hashValue)")
-//            print("🦦 \(value?.linkDepth ?? 0)")
             context = value
         }
         .onPreferenceChange(AnimationAnchorKey.self) { anchor in
@@ -464,7 +461,7 @@ public struct FlowLink<Label>: View where Label: View {
 
     private func initSnapshots() {
         Task {
-            // Prevent Snapshot from being taken too early
+            // Prevent Snapshot from being taken too early before Fetchable content loads
             try? await Task.sleep(10000)
                 let lightImage = createSnapshot(colorScheme: .light)
                 let darkImage = createSnapshot(colorScheme: .dark)
@@ -473,7 +470,6 @@ public struct FlowLink<Label>: View where Label: View {
         }
     }
 }
-
 
 private struct IgnoreAnimationModifier: ViewModifier {
     @State var shouldDisplay = true

--- a/Sources/FlowStack/FlowPath.swift
+++ b/Sources/FlowStack/FlowPath.swift
@@ -28,6 +28,7 @@ struct PathContext: Equatable, Hashable {
     var overrideAnchor: Anchor<CGRect>?
 
     var snapshot: UIImage?
+    var snapshotDict: [ColorScheme: UIImage] = [:]
     var linkDepth: Int = 0
 
     var cornerRadius: CGFloat = 0
@@ -98,6 +99,19 @@ public struct FlowPath: Equatable, Hashable {
     ///   - newElement: The element to append to the flow path.
     public mutating func append<P>(_ newElement: P) where P: Hashable {
         self.append(newElement, context: nil)
+    }
+
+    /// Adds a method to tell flowPath to use the correct snapshot for the respective colorScheme
+    public mutating func updateSnapshots(from colorScheme: ColorScheme) {
+        for i in elements.indices {
+            guard var context = elements[i].context else { continue }
+
+            if let newSnapshot = context.snapshotDict[colorScheme] {
+                print("🦦 Entered on colorScheme -> \(colorScheme)")
+                context.snapshot = newSnapshot
+                elements[i].context = context
+            }
+        }
     }
 }
 

--- a/Sources/FlowStack/FlowPath.swift
+++ b/Sources/FlowStack/FlowPath.swift
@@ -50,13 +50,11 @@ struct FlowElement: Equatable, Hashable {
     static func == (lhs: FlowElement, rhs: FlowElement) -> Bool {
         lhs.value.hashValue == rhs.value.hashValue &&
         _mangledTypeName(type(of: lhs.value)) == _mangledTypeName(type(of: rhs.value)) &&
-        lhs.context == rhs.context &&
         lhs.index == rhs.index
     }
 
     func hash(into hasher: inout Hasher) {
         hasher.combine(_mangledTypeName(type(of: value)))
-        hasher.combine(context)
         hasher.combine(index)
     }
 }
@@ -103,13 +101,14 @@ public struct FlowPath: Equatable, Hashable {
 
     /// Adds a method to tell flowPath to use the correct snapshot for the respective colorScheme
     public mutating func updateSnapshots(from colorScheme: ColorScheme) {
+        print("🦦 \(elements.count)")
         for i in elements.indices {
             guard var context = elements[i].context else { continue }
 
             if let newSnapshot = context.snapshotDict[colorScheme] {
-                print("🦦 Entered on colorScheme -> \(colorScheme)")
+
                 context.snapshot = newSnapshot
-                elements[i].context = context
+                elements[i].context?.snapshot = context.snapshot
             }
         }
     }

--- a/Sources/FlowStack/FlowPath.swift
+++ b/Sources/FlowStack/FlowPath.swift
@@ -99,14 +99,13 @@ public struct FlowPath: Equatable, Hashable {
         self.append(newElement, context: nil)
     }
 
-    /// Adds a method to tell flowPath to use the correct snapshot for the respective colorScheme
+    /// Adds a method to tell flow path to use the correct snapshot for the currently set colorScheme
+    /// - Parameters:
+    ///    - colorScheme: The new color scheme to be used for snapshots
     public mutating func updateSnapshots(from colorScheme: ColorScheme) {
-        print("🦦 \(elements.count)")
         for i in elements.indices {
             guard var context = elements[i].context else { continue }
-
             if let newSnapshot = context.snapshotDict[colorScheme] {
-
                 context.snapshot = newSnapshot
                 elements[i].context?.snapshot = context.snapshot
             }


### PR DESCRIPTION
Changes: 
- FlowStack now appropriately captures theme changes. 
- FlowStack's PathContext Object now stores a dictionary of two snapshots for .dark and .light .This is because taking a snapshot while in the destination View causes a poor visual transition and captures the destination rather than the source.
- FlowStack's Equatable function no longer compares it's context. This is due to the fact that on a themeChange, the previous PathContext's currentSnapshot is being changed to that of its other theme. 