### PR TITLE
Color Scheme Snapshot Wrong Theme iOS 26

### DIFF
--- a/Sources/FlowStack/FlowLink.swift
+++ b/Sources/FlowStack/FlowLink.swift
@@ -276,7 +276,6 @@ public struct FlowLink<Label>: View where Label: View {
     @State var environmentList: [EnvironmentValues] = []
     @State private var snapshots: [ColorScheme: UIImage] = [:]
     @State private var environment = EnvironmentValues()
-    @State private var refreshButton = UUID()
 
     /// Creates a flow link that presents the view corresponding to a value.
     ///
@@ -400,14 +399,12 @@ public struct FlowLink<Label>: View where Label: View {
                 .onButtonGesture {
                     trigger()
                 }
-                .id(refreshButton)
         case .tapGesture:
             label()
                 .contentShape(Rectangle())
                 .onTapGesture {
                     trigger()
                 }
-                .id(refreshButton)
         }
     }
 
@@ -433,7 +430,6 @@ public struct FlowLink<Label>: View where Label: View {
         }
         .onChange(of: colorScheme) { newScheme in
             path?.wrappedValue.updateSnapshots(from: newScheme)
-            refreshButton = UUID()
         }
         .background(
             GeometryReader { proxy in

--- a/Sources/FlowStack/FlowTransition.swift
+++ b/Sources/FlowStack/FlowTransition.swift
@@ -80,6 +80,8 @@ extension AnyTransition {
         @State private var snapCornerRadiusZero: Bool = true
         @State private var availableSize: CGSize = .zero
 
+        @Environment(\.colorScheme) private var colorScheme
+
         private var snapshotPercent: CGFloat {
             max(0, 1 - percent / 0.2)
         }
@@ -87,6 +89,10 @@ extension AnyTransition {
         @Environment(\.flowDismiss) var dismiss
         @Environment(\.flowTransaction) var transaction
         @Environment(\.horizontalSizeClass) var horizontalSizeClass
+
+        private var activeSnapshot: UIImage? {
+            context.snapshotDict[colorScheme] ?? context.snapshot
+        }
 
         var cornerRadius: CGFloat { context.cornerRadius + ((UIScreen.displayCornerRadius ?? 20) - context.cornerRadius) * percent }
 
@@ -186,7 +192,7 @@ extension AnyTransition {
                         availableSize = value
                     })
                     .overlay(alignment: .top) {
-                        if let image = context.snapshot, percent < 1 {
+                        if let image = activeSnapshot, percent < 1 {
                             Image(uiImage: image)
                                 .resizable()
                                 .aspectRatio(contentMode: .fit)


### PR DESCRIPTION
## Changes: 
- Color Scheme is now correct for view and snapshot no matter the scenario of the environment's color scheme